### PR TITLE
Updated response-handling to support more rest-requests

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,4 +1,4 @@
 ---
 :major: 1
 :minor: 1
-:patch: 4
+:patch: 3

--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -632,7 +632,7 @@ module MiniFB
                 @@log.debug 'url_get=' + url if @@logging
                 resp = RestClient.get url
             end
-
+
             if options[:response_type] == :params
                 # Some methods return a param like string, for example: access_token=11935261234123|rW9JMxbN65v_pFWQl5LmHHABC
                 params = {}


### PR DESCRIPTION
Hi!

I've modified the response-handling of MiniFB.fetch to support more Rest-based api-calls, most notably 'friends.getAppUsers'. It checks if all the items returned are hashes (i.e. this is an fql-call) - if so, treat is as fql - otherwise it's possibly an rest-api call (such as 'friends.getAppUsers' which returns a basic array of ids) and the created Hashie::Mash contains the array on the "data"-key. 

I've also update the Readme to reflect this very minor update.

Cheers, 
Daniel
