### PR TITLE
URI.escape => CGI.escape

### DIFF
--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -633,7 +633,7 @@ module MiniFB
                 resp = RestClient.get url
             end
 
-            @@log.debug 'resp=' + resp.to_s
+            @@log.debug 'resp=' + resp.to_s if @@logging
 
             if options[:response_type] == :params
                 # Some methods return a param like string, for example: access_token=11935261234123|rW9JMxbN65v_pFWQl5LmHHABC


### PR DESCRIPTION
I was having problems paging through results, because the until date/times were not being properly escaped.  Passing in pre-escaped fields also failed, because the %'s were double-escaped.

Changing from URI.escape to CGI.escape (and excluding the "=" from the escaping) fixed this.  See my two commits.

Thanks,

Paul
