### PR TITLE
Add Support for multiget

### DIFF
--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -387,7 +387,7 @@ module MiniFB
         end
         
         def multiget(ids, options={})
-            MiniFB.get(@access_token, ids, session_options(options))
+            MiniFB.multiget(@access_token, ids, session_options(options))
         end
 
         def post(id, options={})

--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -385,6 +385,10 @@ module MiniFB
         def get(id, options={})
             MiniFB.get(@access_token, id, session_options(options))
         end
+        
+        def multiget(ids, options={})
+            MiniFB.get(@access_token, ids, session_options(options))
+        end
 
         def post(id, options={})
             MiniFB.post(@access_token, id, session_options(options))
@@ -547,6 +551,28 @@ module MiniFB
         url = "#{graph_base}#{id}"
         url << "/#{options[:type]}" if options[:type]
         params = options[:params] || {}
+        params["access_token"] = "#{(access_token)}"
+        params["metadata"] = "1" if options[:metadata]
+        params["fields"] = options[:fields].join(",") if options[:fields]
+        options[:params] = params
+        return fetch(url, options)
+    end
+    
+    # Gets multiple data from the Facebook Graph API
+    # options:
+    #   - type: eg: feed, home, etc
+    #   - metadata: to include metadata in response. true/false
+    #   - params: Any additional parameters you would like to submit
+    # Example:
+    #
+    # MiniFB.multiget(access_token, [123, 234])
+    #
+    # Can throw a connection Timeout if there is too many items
+    def self.multiget(access_token, ids, options={})
+        url = "#{graph_base}"
+        url << "#{options[:type]}" if options[:type]
+        params = options[:params] || {}
+        params["ids"] = ids.join(',')
         params["access_token"] = "#{(access_token)}"
         params["metadata"] = "1" if options[:metadata]
         params["fields"] = options[:fields].join(",") if options[:fields]


### PR DESCRIPTION
From http://developers.facebook.com/docs/api :
You can also request multiple objects in a single query using the "ids" query parameter. For example, the URL https://graph.facebook.com?ids=arjun,vernal returns both profiles in the same response.

The "ids" query parameter also accepts URLs. This is useful for finding IDs of URLs in the Open Graph. For example: https://graph.facebook.com/?ids=http://www.imdb.com/title/tt0117500/

Multiget method allows to fetch multiple objects with one request