### PR TITLE
Adds public search method.

### DIFF
--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -564,6 +564,22 @@ module MiniFB
         return fetch(url, options)
     end
 
+    # Searches the entire public Graph API
+    # options:
+    #   - type: eg: feed, home, etc
+    #   - metadata: to include metadata in response. true/false
+    #   - params: Any additional parameters you would like to submit
+    def self.search(access_token, options={})
+        url = "#{graph_base}search"
+        url << "/#{options[:type]}" if options[:type]
+        params = options[:params] || {}
+        params["access_token"] = "#{(access_token)}"
+        params["metadata"] = "1" if options[:metadata]
+        params["fields"] = options[:fields].join(",") if options[:fields]
+        options[:params] = params
+        return fetch(url, options)
+    end
+
     # Posts data to the Facebook Graph API
     # options:
     #   - type: eg: feed, home, etc


### PR DESCRIPTION
Currently it is possible to search public posts with MiniFB by abusing the id parameter of `MiniFB.get`. However, this is not obvious without dipping into the source code and is also prone to breaking if someone refactors the get method. Thus I have created a nearly identical method which omits the `id` parameter in favor of searching all public posts.