### PR TITLE
Fix for when facebook returns 'true' as response

### DIFF
--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -684,6 +684,7 @@ module MiniFB
             if res_hash.is_a? Array # fql  return this
                 res_hash.collect! { |x| x.is_a?(Hash) ? Hashie::Mash.new(x) : x }
             else
+                res_hash = { response: res_hash } unless res_hash.is_a? Hash
                 res_hash = Hashie::Mash.new(res_hash)
             end
 


### PR DESCRIPTION
It gets parsed fine by JSON.parse('true') => true. Mash does not like
receiving that in constructor though, because it expects a hash.
