### PR TITLE
Fix authenticate_as_app with logging enabled

### DIFF
--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -562,7 +562,7 @@ module MiniFB
         options[:method] = :get
         options[:response_type] = :params
         resp = fetch(url, options)
-        puts 'resp=' + resp.body.to_s if @@logging
+        puts 'resp=' + resp if @@logging
         resp
     end
 


### PR DESCRIPTION
NoMethodError: undefined method `body' for {"access_token"=>"1426088894273662|dJE00nxA_buHZHdFLOWMtkYTHXA"}:Hash
