### PR TITLE
Replace rest_client for rest-client

### DIFF
--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -14,7 +14,7 @@
 require 'digest/md5'
 require 'erb'
 require 'json' unless defined? JSON
-require 'rest_client'
+require 'rest-client'
 require 'hashie'
 require 'base64'
 require 'openssl'


### PR DESCRIPTION
WARNING: The rest_client gem is deprecated and will be removed from RubyGems. Please use rest-client gem instead.