### PR TITLE
Eliminates duplication in gemspec

### DIFF
--- a/mini_fb.gemspec
+++ b/mini_fb.gemspec
@@ -30,17 +30,11 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rest-client>, [">= 0"])
       s.add_runtime_dependency(%q<hashie>, [">= 0"])
-      s.add_runtime_dependency(%q<rest-client>, [">= 0"])
-      s.add_runtime_dependency(%q<hashie>, [">= 0"])
     else
-      s.add_dependency(%q<rest-client>, [">= 0"])
-      s.add_dependency(%q<hashie>, [">= 0"])
       s.add_dependency(%q<rest-client>, [">= 0"])
       s.add_dependency(%q<hashie>, [">= 0"])
     end
   else
-    s.add_dependency(%q<rest-client>, [">= 0"])
-    s.add_dependency(%q<hashie>, [">= 0"])
     s.add_dependency(%q<rest-client>, [">= 0"])
     s.add_dependency(%q<hashie>, [">= 0"])
   end


### PR DESCRIPTION
To get rid of bundler error:

```
The gemspec at /rubies/ruby-2.1.6/lib/ruby/gems/2.1.0/bundler/gems/mini_fb-41de5a417b69/mini_fb.gemspec is not valid. The validation error was 'duplicate dependency on rest-client (>= 0), (>= 0) use:
    add_runtime_dependency 'rest-client', '>= 0', '>= 0'
'
```