### PR TITLE
Replace rest client

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
 :major: 2
-:minor: 0
+:minor: 1
 :patch: 0
-:build: 
+:build:

--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -14,7 +14,7 @@
 require 'digest/md5'
 require 'erb'
 require 'json' unless defined? JSON
-require 'rest_client'
+require 'httpclient'
 require 'hashie'
 require 'base64'
 require 'openssl'
@@ -28,6 +28,8 @@ module MiniFB
 
     @@logging = false
     @@log = Logger.new(STDOUT)
+    @@http = HTTPClient.new
+
 
     def self.log_level=(level)
         if level.is_a? Numeric
@@ -507,7 +509,7 @@ module MiniFB
         oauth_url << "&redirect_uri=#{CGI.escape(redirect_uri)}"
         oauth_url << "&client_secret=#{secret}"
         oauth_url << "&code=#{CGI.escape(code)}"
-        resp = RestClient.get oauth_url
+        resp = @@http.get oauth_url
         puts 'resp=' + resp.body.to_s if @@logging
         params = {}
         params_array = resp.split("&")
@@ -525,7 +527,7 @@ module MiniFB
         oauth_url << "&client_secret=#{secret}"
         oauth_url << "&grant_type=fb_exchange_token"
         oauth_url << "&fb_exchange_token=#{CGI.escape(access_token)}"
-        resp = RestClient.get oauth_url
+        resp = @@http.get oauth_url
         puts 'resp=' + resp.body.to_s if @@logging
         params = {}
         params_array = resp.split("&")
@@ -556,7 +558,6 @@ module MiniFB
         params["type"] = "client_cred"
         params["client_id"] = "#{app_id}"
         params["client_secret"] = "#{secret}"
-#      resp = RestClient.get url
         options = {}
         options[:params] = params
         options[:method] = :get
@@ -700,22 +701,24 @@ module MiniFB
             case options[:method]
             when :post
                 @@log.debug 'url_post=' + url if @@logging
-                resp = RestClient.post url, options[:params]
+                response = @@http.post url, options[:params]
             when :delete
                 if options[:params] && options[:params].size > 0
                     url += '?' + options[:params].map { |k, v|  CGI.escape(k.to_s) + '=' + CGI.escape(v.to_s) }.join('&')
                 end
                 @@log.debug 'url_delete=' + url if @@logging
-                resp = RestClient.delete url
+                response = @@http.delete url
             else
                 if options[:params] && options[:params].size > 0
                     url += '?' + options[:params].map { |k, v|  CGI.escape(k.to_s) + '=' + CGI.escape(v.to_s) }.join('&')
                 end
                 @@log.debug 'url_get=' + url if @@logging
-                resp = RestClient.get url
+                response = @@http.get url
             end
 
-            @@log.debug 'resp=' + resp.to_s if @@log.debug?
+            resp = response.body
+            @@log.debug 'Response = ' + resp if @@logging
+            @@log.debug 'API Version =' + resp.headers["Facebook-API-Version"].to_s if @@logging
 
             if options[:response_type] == :params
                 # Some methods return a param like string, for example: access_token=11935261234123|rW9JMxbN65v_pFWQl5LmHHABC
@@ -747,11 +750,11 @@ module MiniFB
             end
 
             return res_hash
-        rescue RestClient::Exception => ex
-            puts "ex.http_code=" + ex.http_code.to_s if @@logging
-            puts 'ex.http_body=' + ex.http_body if @@logging
-            res_hash = JSON.parse(ex.http_body) # probably should ensure it has a good response
-            raise MiniFB::FaceBookError.new(ex.http_code, "#{res_hash["error"]["type"]}: #{res_hash["error"]["message"]}")
+        rescue Exception => ex
+            puts "ex.http_code=" + response.status if @@logging
+            puts 'ex.http_body=' + resp if @@logging
+            res_hash = JSON.parse(resp) # probably should ensure it has a good response
+            raise MiniFB::FaceBookError.new(response.status, "#{res_hash["error"]["type"]}: #{res_hash["error"]["message"]}")
         end
 
     end

--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -14,7 +14,7 @@
 require 'digest/md5'
 require 'erb'
 require 'json' unless defined? JSON
-require 'rest-client'
+require 'rest_client'
 require 'hashie'
 require 'base64'
 require 'openssl'
@@ -581,7 +581,7 @@ module MiniFB
         options[:params] = params
         return fetch(url, options)
     end
-    
+
     # Gets multiple data from the Facebook Graph API
     # options:
     #   - type: eg: feed, home, etc
@@ -628,7 +628,7 @@ module MiniFB
         return fetch(url, options)
 
     end
-    
+
     # Sends a DELETE request to the Facebook Graph API
     # options:
     #   - type: eg: feed, home, etc

--- a/mini_fb.gemspec
+++ b/mini_fb.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "mini_fb"
-  s.version = "2.1.1"
+  s.version = "2.1.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Travis Reeder"]
@@ -28,14 +28,14 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rest-client>, [">= 0"])
+      s.add_runtime_dependency(%q<httpclient>, [">= 0"])
       s.add_runtime_dependency(%q<hashie>, [">= 0"])
     else
-      s.add_dependency(%q<rest-client>, [">= 0"])
+      s.add_dependency(%q<httpclient>, [">= 0"])
       s.add_dependency(%q<hashie>, [">= 0"])
     end
   else
-    s.add_dependency(%q<rest-client>, [">= 0"])
+    s.add_dependency(%q<httpclient>, [">= 0"])
     s.add_dependency(%q<hashie>, [">= 0"])
   end
 end

--- a/mini_fb.gemspec
+++ b/mini_fb.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "mini_fb"
-  s.version = "2.0.0"
+  s.version = "2.1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Travis Reeder"]
@@ -39,4 +39,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<hashie>, [">= 0"])
   end
 end
-


### PR DESCRIPTION
Remove RestClient because is one the slowest HTTP Clients for Ruby to one of the best HTTPClient (https://github.com/nahi/httpclient)

Source:
https://bibwild.wordpress.com/2012/04/30/ruby-http-performance-shootout-redux/