### PR TITLE
Prevent parsing empty response in self.fetch

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
 :major: 2
 :minor: 1
-:patch: 1
+:patch: 2
 :build:

--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -724,7 +724,7 @@ module MiniFB
         @@log.debug "Response = #{resp}. Status = #{response.status}" if @@logging
         @@log.debug 'API Version =' + response.headers["Facebook-API-Version"].to_s if @@logging
 
-        res_hash = JSON.parse(resp)
+        res_hash = JSON.parse(resp.to_s.size > 2 ? resp.to_s : {response: resp.to_s}.to_json)
 
         unless response.ok?
             raise MiniFB::FaceBookError.new(response.status, "#{res_hash["error"]["type"]}: #{res_hash["error"]["message"]}")
@@ -740,12 +740,7 @@ module MiniFB
             end
             return params
         else
-            begin
-                res_hash = JSON.parse(resp.to_s)
-            rescue
-                # quick fix for things like stream.publish that don't return json
-                res_hash = JSON.parse("{\"response\": #{resp.to_s}}")
-            end
+            res_hash = JSON.parse(resp.to_s.size > 2 ? resp.to_s : {response: resp.to_s}.to_json)
         end
 
         if res_hash.is_a? Array # fql  return this

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module MiniFB
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
@treeder take a look to this. I returned the empty JSON prevent but without the rescue (slower, uglier).