### PR TITLE
clean tests, handle unsuccessful request in fb_exchange_token

### DIFF
--- a/spec/mini_fb_spec.rb
+++ b/spec/mini_fb_spec.rb
@@ -3,65 +3,64 @@ require 'uri'
 require 'yaml'
 require 'active_support/core_ext'
 require_relative '../lib/mini_fb'
+require_relative 'test_helper'
 
 describe MiniFB do
+  before do
+    MiniFB.log_level = :warn
+  end
 
-    before :all do
-        @is_setup = true
-        file_path = File.expand_path("../mini_fb_tests.yml", File.dirname(__FILE__))
-        @config   = File.open(file_path) { |yf| YAML::load(yf) }
-        MiniFB.log_level = :warn
+  let(:app_id){TestHelper.config['app_id']}
+  let(:app_secret){TestHelper.config['app_secret']}
+  let(:access_token){TestHelper.config['access_token']}
 
-        @oauth_url       = MiniFB.oauth_url(@config['fb_app_id'],
-                                            "http://localhost:3000", # redirect url
-                                            :scope=>MiniFB.scopes.join(","))
+  describe '#authenticate_as_app' do
+
+    it 'authenticates with valid params' do
+      res = MiniFB.authenticate_as_app(app_id, app_secret)
+      expect(res).to include('access_token')
+      expect(res['access_token']).to match(/^#{app_id}/)
+    end
+  end
+
+  describe '#signed_request_params' do
+    let (:req) { 'vlXgu64BQGFSQrY0ZcJBZASMvYvTHu9GQ0YM9rjPSso.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsIjAiOiJwYXlsb2FkIn0' }
+    let (:secret) { 'secret' }
+
+    it 'decodes params' do
+      expect(MiniFB.signed_request_params(secret, req)).to eq({"0" => "payload"})
+    end
+  end
+
+  describe '#exchange_token' do
+    let(:invalid_app_id) { '12345' }
+    let(:invalid_secret) { 'secret' }
+    let(:invalid_access_token) { 'token' }
+
+    it 'returns valid long-lived token' do
+      res = MiniFB.fb_exchange_token(app_id, app_secret, access_token)
+
+      expect(res).to include('access_token')
+      expect(res).to include('expires')
     end
 
+    it 'raises error on request with invalid params' do
+      error_message = 'Facebook error 400: OAuthException: '\
+        'Error validating application. '\
+        'Cannot get application info due to a system error.'
 
-
-    before :each do
-        # this code runs once per-test
+      expect do
+        MiniFB.fb_exchange_token(invalid_app_id, invalid_secret, invalid_access_token)
+      end.to raise_error(MiniFB::FaceBookError, error_message)
     end
 
-    it 'test_uri_escape' do
-        URI.escape("x=y").should eq("x=y")
+    it 'raise error on request with invalid token' do
+      error_message = 'Facebook error 400: OAuthException: '\
+        'Invalid OAuth access token.'
+
+      expect do
+        MiniFB.fb_exchange_token(app_id, app_secret, invalid_access_token)
+      end.to raise_error(MiniFB::FaceBookError, error_message)
     end
-
-    it 'test_authenticate_as_app' do
-        res = MiniFB.authenticate_as_app(@config["fb_api_key"], @config["fb_secret"])
-        res.should include("access_token")
-        res["access_token"].should match(/^#{@config['fb_app_id']}/)#starts_with?(@config["fb_app_id"].to_s)
-    end
-
-
-    it 'test_signed_request_params' do
-        # Example request and secret taken from http://developers.facebook.com/docs/authentication/canvas
-        secret = 'secret'
-        req = 'vlXgu64BQGFSQrY0ZcJBZASMvYvTHu9GQ0YM9rjPSso.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsIjAiOiJwYXlsb2FkIn0'
-        expect(MiniFB.signed_request_params(secret, req)).to eq({"0" => "payload"})
-    end
-
-end
-
-
-def access_token
-    @config['access_token']
-end
-
-
-def test_me_with_fields
-    fields = {
-            'interests' => [:name],
-            'activities'=> [:name],
-            'music'     => [:name],
-            'videos'    => [:name],
-            'television'=> [:name],
-            'movies'    => [:name],
-            'likes'     => [:name],
-            'work'      => [:name],
-            'education' => [:name],
-            'books'     => [:name]
-    }
-
-    snap   = MiniFB.get(access_token, 'me', :fields =>fields.keys)
+  end
 end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,0 +1,14 @@
+module TestHelper
+  class << self
+    
+    def config
+      @config  ||= File.open(config_path) { |yf| YAML::load(yf) }
+    end
+
+    private
+
+      def config_path
+        File.expand_path("../mini_fb_tests.yml", File.dirname(__FILE__))
+      end
+  end
+end


### PR DESCRIPTION
 fb_exchange_token doesn't handle unsuccessful responses from Facebook Graph API.
For example, if we pass invalid token, it returns hash with one element: key - response message, value - nil
```
{
    "{\"error\":{\"message\":\"Invalid OAuth access token.\",\"type\":\"OAuthException\",\"code\":190,\"fbtrace_id\":\"C3+iZ7Bch8I\"}}" => nil
}
```
I cleaned specs and fixed this issue. 
