### PR TITLE
fix(mini_fb.oauth_access_token): returns a JSON response, so simply p…

### DIFF
--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -511,13 +511,7 @@ module MiniFB
         oauth_url << "&code=#{CGI.escape(code)}"
         resp = @@http.get oauth_url
         puts 'resp=' + resp.body.to_s if @@logging
-        params = {}
-        params_array = resp.body.to_s.split("&")
-        params_array.each do |p|
-            ps = p.split("=")
-            params[ps[0]] = ps[1]
-        end
-        return params
+        JSON.parse(resp.body.to_s)
     end
 
     # Gets long-lived token from the Facebook Graph API

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module MiniFB
-  VERSION = "2.2.1"
+  VERSION = "2.2.3"
 end


### PR DESCRIPTION
apparently FB api changed, response are json response (looked to be a string previously ; can't remember)