### PR TITLE
Bugfix/incorrect format data from exchange token

### DIFF
--- a/lib/mini_fb.rb
+++ b/lib/mini_fb.rb
@@ -519,7 +519,7 @@ module MiniFB
     #   - app_id: your app ID (string)
     #   - secret: your app secret (string)
     #   - access_token: short-lived user token (string)
-    # returns a hash with one value being 'access_token', the other being 'expires'
+    # returns a hash with one value being 'access_token', the other being 'expires_in'
     #
     # Throws MiniFB::FaceBookError if response from Facebook Graph API is not successful
     def self.fb_exchange_token(app_id, secret, access_token)
@@ -531,17 +531,11 @@ module MiniFB
         response = @@http.get oauth_url
         body = response.body.to_s
         puts 'resp=' + body if @@logging
+        res_hash = JSON.parse(body)
         unless response.ok?
-          res_hash = JSON.parse(body)
           raise MiniFB::FaceBookError.new(response.status, "#{res_hash["error"]["type"]}: #{res_hash["error"]["message"]}")
         end
-        params = {}
-        params_array = body.split("&")
-        params_array.each do |p|
-            ps = p.split("=")
-            params[ps[0]] = ps[1]
-        end
-        return params
+        return res_hash
     end
 
     # Return a JSON object of working Oauth tokens from working session keys, returned in order given
@@ -567,7 +561,7 @@ module MiniFB
         options = {}
         options[:params] = params
         options[:method] = :get
-        options[:response_type] = :params
+        options[:response_type] = :json
         resp = fetch(url, options)
         puts 'resp=' + resp.to_s if @@logging
         resp

--- a/spec/mini_fb_spec.rb
+++ b/spec/mini_fb_spec.rb
@@ -41,7 +41,7 @@ describe MiniFB do
       res = MiniFB.fb_exchange_token(app_id, app_secret, access_token)
 
       expect(res).to include('access_token')
-      expect(res).to include('expires')
+      expect(res).to include('expires_in')
     end
 
     it 'raises error on request with invalid params' do


### PR DESCRIPTION
In connection with issue #68 
Also, when I run tests, format of `authenticate_as_app` response data also changed, so, I added it to fix too.
@treeder 